### PR TITLE
add --show-trace to agenix CLI

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -9,7 +9,7 @@ writeShellScriptBin "agenix" ''
 
   function die() { echo "[1;31merror:[m $*" >&2; exit 1; }
   function show_help() {
-    echo 'Usage: agenix [COMMAND]'
+    echo 'Usage: agenix <OPTIONS> [COMMAND]'
     echo "Edit, generate or rekey secrets for agenix."
     echo "Add help or --help to a subcommand to view a command specific help."
     echo ""
@@ -17,6 +17,10 @@ writeShellScriptBin "agenix" ''
     echo '  rekey                   Re-encrypts secrets for hosts that require them.'
     echo '  edit                    Create/edit age secret files with $EDITOR and your master identity'
     echo '  generate                Automatically generates secrets that have generators'
+    echo ""
+    echo 'OPTIONS:'
+    echo '  --show-trace            Show the trace for agenix-rekey.  This must be provided before the'
+    echo '                            subcommand or it will be provided to the subcommand.'
   }
 
   USER_GIT_TOPLEVEL=$(realpath -e "$(git rev-parse --show-toplevel 2>/dev/null || pwd)") \
@@ -38,19 +42,44 @@ writeShellScriptBin "agenix" ''
     exit 1
   }
 
-  case "$1" in
-    "help"|"--help"|"-help"|"-h")
-      show_help
-      exit 1
-      ;;
-
-    ${lib.concatStringsSep "|" allApps})
-      APP=$1
-      shift
-      echo "Collecting information about hosts. This may take a while..."
-      exec nix run .#agenix-rekey.apps.${lib.escapeShellArg stdenv.hostPlatform.system}."$APP" -- "$@"
-      ;;
-
-    *) die "Unknown command: $1" ;;
-  esac
+  APP=""
+  SHOW_TRACE_ARG=""
+  # Various Bash versions treat empty arrays as unset, which then trigger
+  # unbound variable errors.
+  PASS_THRU_ARGS=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      "help"|"--help"|"-help"|"-h")
+        show_help
+        exit 1
+        ;;
+      "--show-trace")
+        # It is potentially desirable to use --show-trace in the subcommand as
+        # well as this command.  To do so, the --show-trace argument must be
+        # provided before (agenix) or after (subcommand) to indicate which one
+        # is to be used.  We account for this here.
+        if [[ "$APP" == "" ]]; then
+          SHOW_TRACE_ARG='--show-trace'
+        else
+          PASS_THRU_ARGS+=('--show-trace')
+        fi
+        shift
+        ;;
+      ${lib.concatStringsSep "|" allApps})
+        APP="$1"
+        shift
+        ;;
+      *)
+        PASS_THRU_ARGS+=("$1")
+        shift
+        ;;
+    esac
+  done
+  if [[ "$APP" == "" ]]; then
+    die "Error: No app provided.  Exiting."
+  fi
+  echo "Collecting information about hosts. This may take a while..."
+  exec nix run $SHOW_TRACE_ARG \
+    .#agenix-rekey.apps.${lib.escapeShellArg stdenv.hostPlatform.system}."$APP" \
+     -- "''${PASS_THRU_ARGS[@]}"
 ''


### PR DESCRIPTION
This allows tracing errors that occur when running `agenix`.  The actual error I've encountered is current immaterial because I believe it is resulting from other, experimental work.  But there is need to debug this work, and the current output is unhelpful (just showing built-in functions with no context).

Other arguments are accumulated and passed along to the subcommand, so there should be no discernible change in existing behavior, including if they previously used `--show-trace` (assuming `--show-trace` is after the subcommand).

Note that the placement of `--show-trace` is important.  If provided `--show-trace` before the subcommand, it applies to `agenix` itself.  If provided after the subcommand, it applies to the subcommand.  Some or all subcommands do not currently use `--show-trace`, but at the very least this will account for future use.  The help text has made an attempt at explaining this.