### PR TITLE
Attempt orphan deletion only if `age.rekey.generatedSecretsDir` is set

### DIFF
--- a/apps/generate.nix
+++ b/apps/generate.nix
@@ -56,7 +56,9 @@
   # If the path already exists, this makes sure that the definition is the same.
   addGeneratedSecretChecked = host: set: secretName: let
     secret = nodes.${host}.config.age.secrets.${secretName};
-    sourceFile = relativeToFlake secret.rekeyFile;
+    sourceFile = assert assertMsg (secret.rekeyFile != null)
+    "age.secrets.${secretName}: `rekeyFile` must be set when using a generator.";
+      relativeToFlake secret.rekeyFile;
     script = secret.generator._script {
       inherit secret pkgs;
       inherit (pkgs) lib;


### PR DESCRIPTION
Fixes #23 by adding the path at `age.rekey.generatedSecretsDir` only as a deletion candidate if it is not `null`.

I have done some basic validation that secret generation and orphan removal with `age.rekey.generatedSecretsDir` set to a sensible value still results in the expected behavior. However, as I usually don't really have an advanced use case of this as a test bed, some more testing might be a good idea.

Also fixes another unhelpful error message similar to the one in #23. Before, when running `agenix generate` with a secret that has `generators` set, but not `rekeyFile`, would result in the same basic error message:
```
error: Cannot generate  as it isn't a direct subpath of the flake directory /nix/store/h9fl1a96wgcsfp4qd7hqnqczi2zp8xva-source, meaning this script cannot determine its true origin!
```
This seems to happen because the module asserts at `./modules/agenix-rekey.nix` appear to be sidestepped when running `agenix generate`. Therefore, we replicate the module-level assert in `./apps/generate.nix`.

---
TIL: The following appears to be valid bash:
``` sh
for f in ; do
  echo "I'm not printed."
done
```