### PR TITLE
fix: only add deleted files to git

### DIFF
--- a/apps/generate.nix
+++ b/apps/generate.nix
@@ -248,16 +248,13 @@ in
         if [[ "''${KNOWN_SECRETS_SET["$f"]-false}" == false ]]; then
           rm -- "$f" || true
           REMOVED_ORPHANS=$((REMOVED_ORPHANS + 1))
+          if [[ "$ADD_TO_GIT" == true ]]; then
+            git add $f
+          fi
         fi
       done
       if [[ "''${REMOVED_ORPHANS}" -gt 0 ]]; then
         echo "[1;36m     Removed[m [0;33m''${REMOVED_ORPHANS} [0;36morphaned files in generation directories[m"
-
-        if [[ "$ADD_TO_GIT" == true ]]; then
-          git add ${pkgs.lib.concatMapStringsSep " "
-      (x: escapeShellArg (relativeToFlake x.config.age.rekey.generatedSecretsDir))
-      nodesWithGeneratedSecretsDir}
-        fi
       fi
     )
   ''


### PR DESCRIPTION
This simplifies the script a bit and fixes two problems:
1. we no longer add unrelated files that might be in the folder.
2. It might happen that the folder does not exist in which case the current script still tries to add it, in which case git will complain the it does not know the pathspec.