### PR TITLE
added ".hmac" to the good suffix list

### DIFF
--- a/modules/agenix-rekey.nix
+++ b/modules/agenix-rekey.nix
@@ -200,7 +200,7 @@ in {
         Please make sure they don't contain any secret information or delete them now.
 
         To silence this warning, you may:
-          - Use a split-identity ending in `.pub`, where the private part is not contained (a yubikey identity)
+          - Use a split-identity ending in `.pub` or `.hmac`, where the private part is not contained (a yubikey identity)
           - Use an absolute path to your key outside of the nix store ("/home/myuser/age-master-key")
           - Or encrypt your age identity and use the extension `.age`. You can encrypt an age identity
             using `rage -p -o privkey.age privkey` which protects it in your store.

--- a/modules/agenix-rekey.nix
+++ b/modules/agenix-rekey.nix
@@ -190,7 +190,7 @@ in {
         ]));
 
     warnings = let
-      hasGoodSuffix = x: (hasPrefix builtins.storeDir x) -> (hasSuffix ".age" x || hasSuffix ".pub" x);
+      hasGoodSuffix = x: (hasPrefix builtins.storeDir x) -> (hasSuffix ".age" x || hasSuffix ".pub" x || hasSuffix ".hmac" x);
     in
       optional (!all hasGoodSuffix masterIdentityPaths) ''
         At least one of your rekey.masterIdentities references an unencrypted age identity in your nix store!


### PR DESCRIPTION
i use agenix and agenix-rekey with the `age-plugin-fido2-hmac` and `age-plugin-tpm` plugins which both produce files pointing to the hardware keystore.
this  setup works, but i have been getting warnings because my files had a `.hmac` suffix and i don't want to rename all of them, so i added this to the suffix list.
it might also be good to add documentation about options other than yubikeys because there are many other FIDO2 devices that are completely compatible.