### PR TITLE
Revert #40 and disable SC2043 shellcheck

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -67,7 +67,7 @@
       # For master identies with no explicit pubkey, try extracting a pubkey from the file first.
       # Collect final identity arguments for encryption in an array.
       masterIdentityArgs=()
-      # shellcheck disable=SC2041
+      # shellcheck disable=SC2041,SC2043
       for file in ${
         concatStringsSep " "
         (map

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -67,14 +67,13 @@
       # For master identies with no explicit pubkey, try extracting a pubkey from the file first.
       # Collect final identity arguments for encryption in an array.
       masterIdentityArgs=()
-      masterIdentityArray=(${
+      # shellcheck disable=SC2041
+      for file in ${
         concatStringsSep " "
         (map
-          (x: ''"${escapeShellArg x.identity}"'')
+          (x: "${escapeShellArg x.identity}")
           (filter (x: x.pubkey == null) mergedMasterIdentities))
-      })
-      # shellcheck disable=SC2041
-      for file in "''${masterIdentityArray[@]}"; do
+      }; do
         # Keep track if a file was processed.
         file_processed=false
 


### PR DESCRIPTION
Fix issue https://github.com/oddlama/agenix-rekey/pull/40 introduced.



Grep seems to consider path as a string and caused the error. This happened when having several `masterIdentities`.

**Haven't been tested** since I have no environment with Multiple keys.

https://github.com/oddlama/agenix-rekey/pull/40#discussion_r1753228726


Thanks @YourFin for reporting

---

Revert #40 and disabled the SC2043 shell check.