### PR TITLE
package: Add submodule support

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -79,6 +79,7 @@ writeShellScriptBin "agenix" ''
           FLAKE_PARAMS="$2"
         fi
         shift
+        shift
         ;;
       ${lib.concatStringsSep "|" allApps})
         APP="$1"

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -77,9 +77,11 @@ writeShellScriptBin "agenix" ''
       "--extra-flake-params")
         if [[ "$APP" == "" ]]; then
           FLAKE_PARAMS="$2"
+          shift
+          shift
+        else
+          die "--extra-flake-params must be specified before the command name"
         fi
-        shift
-        shift
         ;;
       ${lib.concatStringsSep "|" allApps})
         APP="$1"

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -21,6 +21,9 @@ writeShellScriptBin "agenix" ''
     echo 'OPTIONS:'
     echo '  --show-trace            Show the trace for agenix-rekey.  This must be provided before the'
     echo '                            subcommand or it will be provided to the subcommand.'
+    echo '  --extra-flake-params    Extra flake parameters to pass to the "nix run" invocation, such as'
+    echo '                            "\?submodules=1" to enable submodule support.'
+
   }
 
   USER_GIT_TOPLEVEL=$(realpath -e "$(git rev-parse --show-toplevel 2>/dev/null || pwd)") \
@@ -44,6 +47,7 @@ writeShellScriptBin "agenix" ''
 
   APP=""
   SHOW_TRACE_ARG=""
+  FLAKE_PARAMS=""
   # Various Bash versions treat empty arrays as unset, which then trigger
   # unbound variable errors.
   PASS_THRU_ARGS=()
@@ -70,6 +74,12 @@ writeShellScriptBin "agenix" ''
         fi
         shift
         ;;
+      "--extra-flake-params")
+        if [[ "$APP" == "" ]]; then
+          FLAKE_PARAMS="$1"
+        fi
+        shift
+        ;;
       ${lib.concatStringsSep "|" allApps})
         APP="$1"
         shift
@@ -86,6 +96,6 @@ writeShellScriptBin "agenix" ''
   fi
   echo "Collecting information about hosts. This may take a while..."
   exec nix run $SHOW_TRACE_ARG \
-    .#agenix-rekey.${lib.escapeShellArg stdenv.hostPlatform.system}."$APP" \
+    ."$FLAKE_PARAMS"#agenix-rekey.${lib.escapeShellArg stdenv.hostPlatform.system}."$APP" \
      -- "''${PASS_THRU_ARGS[@]}"
 ''

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -76,7 +76,7 @@ writeShellScriptBin "agenix" ''
         ;;
       "--extra-flake-params")
         if [[ "$APP" == "" ]]; then
-          FLAKE_PARAMS="$1"
+          FLAKE_PARAMS="$2"
         fi
         shift
         ;;


### PR DESCRIPTION
Related to #46, it seems this simple change makes it work. 

```
❯ nix run github:Toomoch/agenix-rekey/patch-1 -- --extra-flake-params \?submodules=1 rekey

Collecting information about hosts. This may take a while...
    Skipping [already rekeyed] h81:duckdns
    Skipping [already rekeyed] h81:secret1
```

A side effect is that with git submodules the `-a` flag does not work as expected:
```
❯ nix run github:Toomoch/agenix-rekey/patch-1 -- --extra-flake-params \?submodules=1 rekey -a

Collecting information about hosts. This may take a while...
warning: Git tree '/home/arnau/projects/nixos-config' is dirty
fatal: Pathspec '././private/secrets/rekeyed/b450' is in submodule 'private'
```
Everything else seems fine.