### PR TITLE
fix: only add home-manager as a node if it has agenix-rekey enabled

### DIFF
--- a/nix/select-nodes.nix
+++ b/nix/select-nodes.nix
@@ -9,7 +9,7 @@
   inherit (lib) mapAttrsToList mapAttrs' nameValuePair foldl' optionalAttrs;
   effectiveNixosConfigurations = nodes // nixosConfigurations; # include legacy parameter
   findHomeManagerForHost = hostName: hostCfg:
-    if (hostCfg ? config.home-manager.users)
+    if (hostCfg ? config.home-manager.users.age.rekey)
     then (mapAttrs' (name: value: nameValuePair "host-${hostName}-user-${name}" {config = value;}) hostCfg.config.home-manager.users)
     else {};
   listNixosConfigsWithHomeManager = mapAttrsToList findHomeManagerForHost effectiveNixosConfigurations;


### PR DESCRIPTION
In #51, I checked only for the presence of home-manager configurations but didn't verify if they had agenix-rekey enabled. Since adding home-manager configurations to nodes is enabled by default (see [flake.nix#L58](https://github.com/oddlama/agenix-rekey/blob/main/flake.nix#L58)), any home-manager configurations that don't include agenix-rekey will throw an error about a missing the .age attribute during the rekeying process.

Apologies for catching this issue only a few hours after the PR was accepted. I had tested it on a "dummy" configuration, but when applying it to my "real" dotfiles, I encountered the error.