### PR TITLE
fix(flake): re-add `{x86_64,aarch64}-darwin` to `flake-parts`'s systems

### DIFF
--- a/examples/flake-parts/flake.nix
+++ b/examples/flake-parts/flake.nix
@@ -18,6 +18,8 @@
       systems = [
         "x86_64-linux"
         "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
       ];
 
       flake = {

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,8 @@
       systems = [
         "x86_64-linux"
         "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
       ];
 
       flake =


### PR DESCRIPTION
Commit cf28dcf rewrote the main `flake.nix` to use `flake-parts`, presumably without change for users, but there is actually one small regression there. The main flake's `perSystem` outputs' `system`s were reduced to only `["x86_64-linux" "aarch64-linux"]`, (accidentally) removing `["x86_64-darwin" "aarch64-darwin"]`.
This commit adds them back (both in the main flake and in the example)