### PR TITLE
fix: improve check for home-manager nodes

### DIFF
--- a/nix/select-nodes.nix
+++ b/nix/select-nodes.nix
@@ -13,6 +13,7 @@ let
     nameValuePair
     foldl'
     optionalAttrs
+    filterAttrs
     ;
 
   effectiveNixosConfigurations =
@@ -30,10 +31,10 @@ let
 
   findHomeManagerForHost =
     hostName: hostCfg:
-    if (hostCfg ? config.home-manager.users.age.rekey) then
-      (mapAttrs' (
-        name: value: nameValuePair "host-${hostName}-user-${name}" { config = value; }
-      ) hostCfg.config.home-manager.users)
+    if (hostCfg ? config.home-manager.users) then
+      mapAttrs' (name: value: nameValuePair "host-${hostName}-user-${name}" { config = value; }) (
+        filterAttrs (_: value: value ? age.rekey) hostCfg.config.home-manager.users
+      )
     else
       { };
 


### PR DESCRIPTION
I am attempting to migrate an existing  config to make use of the new home-manager support. I'm able to make use of the home-manager module, but the rekey CLI does not pick up my home-manager nodes. 

I was able to isolate the issue to `/nix/select-nodes.nix` in the repl:

```
nix-repl> :lf .
warning: Git tree '/home/dan/nixos' is dirty
Added 21 variables.

nix-repl> select-nodes = import ../Projects/agenix-rekey/nix/select-nodes.nix                                   

nix-repl> lib = inputs.nixpkgs.lib                                                                              

nix-repl> homeConfigurations = {}

nix-repl> collectHomeManagerConfigurations = true                                                              

nix-repl> select-nodes { inherit lib nixosConfigurations homeConfigurations collectHomeManagerConfigurations; }
{
  burnham = { ... };
  cochichewick = { ... };
  concord = { ... };
  contoocook = { ... };
  deepbrook = { ... };
  marden = { ... };
  merrimack = { ... };
  pennichuck = { ... };
  plum = { ... };
  suncook = { ... };
  winni = { ... };
}
```

I can get my home manager to appear as a configuration by adding a dummy `age` user with a `rekey` configuration:

```
home-manager.users.age.rekey = {}
```

```
nix-repl> :lf .                                                                                                 
warning: Git tree '/home/dan/nixos' is dirty
Added 21 variables.

nix-repl> select-nodes { inherit lib nixosConfigurations homeConfigurations collectHomeManagerConfigurations; }
{
  burnham = { ... };
  cochichewick = { ... };
  concord = { ... };
  contoocook = { ... };
  deepbrook = { ... };
  host-concord-user-age = { ... };
  host-concord-user-dan = { ... };
  host-merrimack-user-age = { ... };
  host-merrimack-user-dan = { ... };
  marden = { ... };
  merrimack = { ... };
  pennichuck = { ... };
  plum = { ... };
  suncook = { ... };
  winni = { ... };
}
```

But that's a bit of a hack, so I created this PR. It results in:

```
nix-repl> select-nodes = import ../Projects/agenix-rekey/nix/select-nodes.nix

nix-repl> select-nodes { inherit lib nixosConfigurations homeConfigurations collectHomeManagerConfigurations; }
{
  burnham = { ... };
  cochichewick = { ... };
  concord = { ... };
  contoocook = { ... };
  deepbrook = { ... };
  host-concord-user-dan = { ... };
  host-merrimack-user-dan = { ... };
  marden = { ... };
  merrimack = { ... };
  pennichuck = { ... };
  plum = { ... };
  suncook = { ... };
  winni = { ... };
}
```

Which is what I want to see.