### PR TITLE
Add `update-masterkeys` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ There are several apps/subcommands which you can use to manage your secrets:
 - `agenix generate`: Generates any secrets that don't exist yet and have a generator set.
 - `agenix edit`: Create/edit secrets using `$EDITOR`. Can encrypt existing files.
 - `agenix rekey`: Rekeys secrets for hosts that require them.
+- `agenix update-masterkeys`: Rekeys secrets for a new set of masterkeys.
 - Use `agenix <command> --help` for specific usage information.
 
 The general workflow is quite simple, because you will automatically be prompted to

--- a/apps/edit.nix
+++ b/apps/edit.nix
@@ -3,34 +3,15 @@ let
   inherit (pkgs.lib)
     concatStringsSep
     escapeShellArg
-    filter
-    hasPrefix
     optionalString
-    removePrefix
-    warn
     ;
 
   inherit (import ../nix/lib.nix inputs)
-    userFlakeDir
-    mergedSecrets
     ageMasterEncrypt
     ageMasterDecrypt
+    validRelativeSecretPaths
     ;
 
-  relativeToFlake =
-    filePath:
-    let
-      fileStr = builtins.unsafeDiscardStringContext (toString filePath);
-    in
-    if hasPrefix userFlakeDir fileStr then
-      "." + removePrefix userFlakeDir fileStr
-    else
-      warn "Ignoring ${fileStr} which isn't a direct subpath of the flake directory ${userFlakeDir}, meaning this script cannot determine it's true origin!" null;
-
-  # Relative path to all rekeyable secrets. Filters and warns on paths that are not part of the root flake.
-  validRelativeSecretPaths = builtins.sort (a: b: a < b) (
-    filter (x: x != null) (map relativeToFlake mergedSecrets)
-  );
 in
 pkgs.writeShellScriptBin "agenix-edit" ''
   set -uo pipefail

--- a/apps/update-masterkeys.nix
+++ b/apps/update-masterkeys.nix
@@ -1,0 +1,54 @@
+{ pkgs, ... }@inputs:
+let
+  inherit (import ../nix/lib.nix inputs)
+    ageMasterEncrypt
+    ageMasterDecrypt
+    validRelativeSecretPaths
+    ;
+in
+pkgs.writeShellScriptBin "agenix-update-masterkeys" ''
+  set -uo pipefail
+
+  function die() { echo "[1;31merror:[m $*" >&2; exit 1; }
+  function show_help() {
+    echo 'Usage: agenix update-masterkeys'
+    echo 'Update all stored secrets with a new set of masterkeys.'
+  }
+
+  if [[ ! -e flake.nix ]] ; then
+    die "Please execute this script from your flake's root directory."
+  fi
+
+  function cleanup() {
+    [[ -e "$CLEARTEXT_FILE" ]] && rm "$CLEARTEXT_FILE"
+    [[ -e "$ENCRYPTED_FILE" ]] && rm "$ENCRYPTED_FILE"
+  }; trap "cleanup" EXIT
+
+  ${builtins.concatStringsSep "" (
+    builtins.map (
+      path: # bash
+      ''
+        CLEARTEXT_FILE=$(mktemp)
+        ENCRYPTED_FILE=$(mktemp)
+
+        shasum_before="$(sha512sum "${path}")"}
+
+        ${ageMasterDecrypt} -o "$CLEARTEXT_FILE" "${path}" \
+            || die "Failed to decrypt file. Aborting."
+        ${ageMasterEncrypt} -o "$ENCRYPTED_FILE" "$CLEARTEXT_FILE" \
+            || die "Failed to re-encrypt file. Aborting."
+
+        shasum_after="$(sha512sum "$ENCRYPTED_FILE")"
+        if [[ "$shasum_before" == "$shasum_after" ]]; then
+          echo "[1;90m    Skipping[m [90m[already rekeyed] "${path}"[m"
+        else
+          cp --no-preserve=all "$ENCRYPTED_FILE" "${path}" # cp instead of mv preserves original attributes and permissions
+          echo "[1;32m    Updated masterkeys of[m [34m"${path}"[m"
+        fi
+
+        rm "$CLEARTEXT_FILE"
+        rm "$ENCRYPTED_FILE"
+      '') validRelativeSecretPaths
+  )}
+  exit 0
+''

--- a/apps/update-masterkeys.nix
+++ b/apps/update-masterkeys.nix
@@ -31,7 +31,7 @@ pkgs.writeShellScriptBin "agenix-update-masterkeys" ''
         CLEARTEXT_FILE=$(mktemp)
         ENCRYPTED_FILE=$(mktemp)
 
-        shasum_before="$(sha512sum "${path}")"}
+        shasum_before="$(sha512sum "${path}")"
 
         ${ageMasterDecrypt} -o "$CLEARTEXT_FILE" "${path}" \
             || die "Failed to decrypt file. Aborting."

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -21,6 +21,7 @@ let
     "edit"
     "generate"
     "rekey"
+    "update-masterkeys"
   ];
 in
 {

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
         "edit"
         "generate"
         "rekey"
+        "update-masterkeys"
       ];
     in
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -17,6 +17,7 @@ writeShellScriptBin "agenix" ''
     echo '  rekey                   Re-encrypts secrets for hosts that require them.'
     echo '  edit                    Create/edit age secret files with $EDITOR and your master identity'
     echo '  generate                Automatically generates secrets that have generators'
+    echo '  update-masterkeys       Update all stored secrets with a new set of masterkeys'
     echo ""
     echo 'OPTIONS:'
     echo '  --show-trace            Show the trace for agenix-rekey.  This must be provided before the'


### PR DESCRIPTION
I received an additional yubikey yesterday, and to my surprise noticed that it's currently not possible to re-encrypt secrets with new/updated keys.

This PR adds a new subcommand, `update-masterkeys`, which simply decrypts, then re-encrypts all known secret files. I have also taken the liberty to move the `validRelativeSecretPaths` expression to the `lib`, since it's in use in multiple plasces now.