### PR TITLE
do not add newlines in generated secrets

### DIFF
--- a/apps/generate.nix
+++ b/apps/generate.nix
@@ -136,7 +136,12 @@ let
           ${contextSecret.script}
         ) || die "Generator exited with status $?."
 
-        ${ageMasterEncrypt} -o ${escapeShellArg contextSecret.sourceFile} <<< "$content" \
+        # Using printf might be less ergonomic than using <<< but <<< injects a
+        # newline.  Many systems or their NixOS modules read secret/password
+        # files literally (openldap, octoprint, and wireguard being some
+        # examples).  This means <<< mangles secrets for these systems.
+        printf '%s' "$content" \
+          | ${ageMasterEncrypt} -o ${escapeShellArg contextSecret.sourceFile} \
           || die "Failed to generate or encrypt secret."
 
         if [[ "$ADD_TO_GIT" == true ]]; then


### PR DESCRIPTION
`<<< "$var"` is the equivalent to `printf '%s\n' "$var"`.  This means we add an extra newline to our secrets as we encrypt them.  Many systems inspect their secret files literally, and interpret the newline as just another character in the secret (as opposed to a POSIX end-of-line+file).  This changes our encryption to use a `printf` expression that does not add a newline, and thus means we no longer mangle secrets emitted to disk.

This should have no impact on systems that filtered the newline in the first place.