### PR TITLE
`secretDir` option for specifying the default parent directory of non-generated secrets

### DIFF
--- a/modules/agenix-rekey.nix
+++ b/modules/agenix-rekey.nix
@@ -2,6 +2,7 @@ nixpkgs:
 {
   lib,
   config,
+  options,
   pkgs,
   ...
 }:
@@ -353,8 +354,13 @@ in
             rekeyFile = mkOption {
               type = types.nullOr types.path;
               default =
-                if config.age.rekey.generatedSecretsDir != null then
-                  config.age.rekey.generatedSecretsDir + "/${submod.config.id}.age"
+                if submod.config.generator != null then
+                  if config.age.rekey.generatedSecretsDir != null then
+                    config.age.rekey.generatedSecretsDir + "/${submod.config.id}.age"
+                  else
+                    null
+                else if config.age.rekey.secretsDir != null then
+                  config.age.rekey.secretsDir + "/${submod.config.id}.age"
                 else
                   null;
               example = literalExpression "./secrets/password.age";
@@ -432,9 +438,19 @@ in
     };
 
     rekey = {
-      generatedSecretsDir = mkOption {
+      secretsDir = mkOption {
         type = types.nullOr types.path;
         default = null;
+        description = ''
+          The default parent path of **non**-generated secrets.  If set, this
+          automatically sets `age.secrets.<name>.rekeyFile` to a default value
+          in this directory for any secret that **does not** define a
+          generator.
+        '';
+      };
+
+      generatedSecretsDir = mkOption {
+        inherit (options.age.rekey.secretsDir) type default;
         description = ''
           The path where all generated secrets should be stored by default.
           If set, this automatically sets `age.secrets.<name>.rekeyFile` to a default


### PR DESCRIPTION
The new `secretDir` option acts like `generatedSecretsDir` for secrets that **are not** generated, permitting specifying such secret paths in relative form.

BREAKING CHANGE: brings the logic of `generatedSecretsDir` in line with its option description ("sets `age.secrets.<name>.rekeyFile` to a default value in this directory, for any secret that defines a generator"), whereas previously *all* secrets were expanded relative to `generatedSecretsDir` if it was defined.