### PR TITLE
fix: escaping Shell args prevents directory from being expanded

### DIFF
--- a/apps/rekey.nix
+++ b/apps/rekey.nix
@@ -101,9 +101,9 @@ let
                 echo "[1;90m    Skipping[m [90m[already rekeyed] "${escapeShellArg hostName}":"${escapeShellArg secretName}"[m"
               else
                 echo "[1;32m    Rekeying[m [90m"${escapeShellArg hostName}":[34m"${escapeShellArg secretName}"[m"
-                if reencrypt ${
+                # Don't escape the out path as it could contain variables we want to expand
+                if reencrypt "${secretOut}" ${
                   escapeShellArgs [
-                    secretOut
                     secret.rekeyFile
                     secretName
                     hostName


### PR DESCRIPTION
fixes: #84

The `secretOut` was recently moved into `escapeShellArgs` which broke shell expansion and all secret wound up in `/tmp/"$UID"/XXX`
instead of `/tmp/1000/XXX`. This moves the secretOut back out so it will be expanded
