### PR TITLE
Use realpath from coreutils for Darwin compatabiity

### DIFF
--- a/apps/generate.nix
+++ b/apps/generate.nix
@@ -230,7 +230,7 @@ pkgs.writeShellScriptBin "agenix-generate" ''
       return 0
     else
       for secret in ''${POSITIONAL_ARGS[@]} ; do
-        [[ "$(realpath -m "$1")" == "$(realpath -m "$secret")" ]] && return 0
+        [[ "$(${pkgs.coreutils}/bin/realpath -m "$1")" == "$(${pkgs.coreutils}/bin/realpath -m "$secret")" ]] && return 0
       done
       # Calculate the number of common lines in the splitted tags. Make sure to always include
       # the empty line so TAGS="" $2="" doesn't produce false positives. If more than one line
@@ -250,7 +250,7 @@ pkgs.writeShellScriptBin "agenix-generate" ''
   )
   for secret in "''${POSITIONAL_ARGS[@]}" ; do
     for known in "''${KNOWN_SECRETS[@]}" ; do
-      [[ "$(realpath -m "$secret")" == "$(realpath -m "$known")" ]] && continue 2
+      [[ "$(${pkgs.coreutils}/bin/realpath -m "$secret")" == "$(${pkgs.coreutils}/bin/realpath -m "$known")" ]] && continue 2
     done
     die "Provided path matches no known secret: $secret"
   done

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -3,6 +3,7 @@
   writeShellScriptBin,
   stdenv,
   allApps,
+  coreutils,
 }:
 writeShellScriptBin "agenix" ''
   set -euo pipefail
@@ -27,9 +28,9 @@ writeShellScriptBin "agenix" ''
 
   }
 
-  USER_GIT_TOPLEVEL=$(realpath -e "$(git rev-parse --show-toplevel 2>/dev/null || pwd)") \
+  USER_GIT_TOPLEVEL=$(${coreutils}/bin/realpath -e "$(git rev-parse --show-toplevel 2>/dev/null || pwd)") \
     || die "Could not determine current working directory. Something went very wrong."
-  USER_FLAKE_DIR=$(realpath -e "$(pwd)") \
+  USER_FLAKE_DIR=$(${coreutils}/bin/realpath -e "$(pwd)") \
     || die "Could not determine current working directory. Something went very wrong."
 
   # Search from $(pwd) upwards to $USER_GIT_TOPLEVEL until we find a flake.nix


### PR DESCRIPTION
Darwin uses a FreeBSD-version of `realpath` and this is the error you see:

```shell
$ agenix --help
realpath: illegal option -- e
usage: realpath [-q] [path ...]
error: Could not determine current working directory. Something went very wrong.
```

Let me know if this approach is too hacky for your taste 🤠 