### PR TITLE
Use coreutils-version of mktemp and sha512sum

### DIFF
--- a/apps/edit.nix
+++ b/apps/edit.nix
@@ -93,8 +93,8 @@ pkgs.writeShellScriptBin "agenix-edit" ''
     SUFFIX="txt"
   fi
 
-  CLEARTEXT_FILE=$(mktemp --suffix=".$SUFFIX")
-  ENCRYPTED_FILE=$(mktemp --suffix=".$SUFFIX")
+  CLEARTEXT_FILE=$(${pkgs.coreutils}/bin/mktemp --suffix=".$SUFFIX")
+  ENCRYPTED_FILE=$(${pkgs.coreutils}/bin/mktemp --suffix=".$SUFFIX")
 
   function cleanup() {
     [[ -e "$CLEARTEXT_FILE" ]] && rm "$CLEARTEXT_FILE"
@@ -110,7 +110,7 @@ pkgs.writeShellScriptBin "agenix-edit" ''
     mkdir -p "$(dirname "$FILE")" \
       || die "Could not create parent directory"
   fi
-  shasum_before="$(sha512sum "$CLEARTEXT_FILE")"
+  shasum_before="$(${pkgs.coreutils}/bin/sha512sum "$CLEARTEXT_FILE")"
 
   if [[ -n ''${INFILE+x} ]] ; then
     cp "$INFILE" "$CLEARTEXT_FILE"
@@ -128,7 +128,7 @@ pkgs.writeShellScriptBin "agenix-edit" ''
       || die "Editor returned unsuccessful exit status. Aborting, original is left unchanged."
   fi
 
-  shasum_after="$(sha512sum "$CLEARTEXT_FILE")"
+  shasum_after="$(${pkgs.coreutils}/bin/sha512sum "$CLEARTEXT_FILE")"
   if [[ "$force" == 0 && "$shasum_before" == "$shasum_after" ]]; then
     echo "No content changes, original is left unchanged."
     exit 0

--- a/apps/rekey.nix
+++ b/apps/rekey.nix
@@ -303,7 +303,7 @@ pkgs.writeShellScriptBin "agenix-rekey" ''
     mkdir -p "$dir" || return
 
     local tmpdir
-    tmpdir="$(mktemp -d "''${dir}/.tmp.agenix-rekey.''${name}.XXXXXXXXXX")" || return
+    tmpdir="$(${pkgs.coreutils}/bin/mktemp -d "''${dir}/.tmp.agenix-rekey.''${name}.XXXXXXXXXX")" || return
 
     local tmp="''${tmpdir}/''${name}"
 

--- a/apps/update-masterkeys.nix
+++ b/apps/update-masterkeys.nix
@@ -28,17 +28,17 @@ pkgs.writeShellScriptBin "agenix-update-masterkeys" ''
     builtins.map (
       path: # bash
       ''
-        CLEARTEXT_FILE=$(mktemp)
-        ENCRYPTED_FILE=$(mktemp)
+        CLEARTEXT_FILE=$(${pkgs.coreutils}/bin/mktemp)
+        ENCRYPTED_FILE=$(${pkgs.coreutils}/bin/mktemp)
 
-        shasum_before="$(sha512sum "${path}")"
+        shasum_before="$(${pkgs.coreutils}/bin/sha512sum "${path}")"
 
         ${ageMasterDecrypt} -o "$CLEARTEXT_FILE" "${path}" \
             || die "Failed to decrypt file. Aborting."
         ${ageMasterEncrypt} -o "$ENCRYPTED_FILE" "$CLEARTEXT_FILE" \
             || die "Failed to re-encrypt file. Aborting."
 
-        shasum_after="$(sha512sum "$ENCRYPTED_FILE")"
+        shasum_after="$(${pkgs.coreutils}/bin/sha512sum "$ENCRYPTED_FILE")"
         if [[ "$shasum_before" == "$shasum_after" ]]; then
           echo "[1;90m    Skipping[m [90m[already rekeyed] "${path}"[m"
         else


### PR DESCRIPTION
More Darwin/BSD vs GNU coreutils discrepancies :)

```
$ agenix edit secrets/access-tokens.age
Collecting information about hosts. This may take a while... warning: Git tree '/Users/pepp/src/github.com/esselius/wrk' is dirty mktemp: unrecognized option `--suffix=.txt'
usage: mktemp [-d] [-p tmpdir] [-q] [-t prefix] [-u] template ...
       mktemp [-d] [-p tmpdir] [-q] [-u] -t prefix
mktemp: unrecognized option `--suffix=.txt'
usage: mktemp [-d] [-p tmpdir] [-q] [-t prefix] [-u] template ...
       mktemp [-d] [-p tmpdir] [-q] [-u] -t prefix
sha512sum: : No such file or directory
sha512sum: : No such file or directory
No content changes, original is left unchanged.