### PR TITLE
fix(flake-module): handle missing `homeConfigurations`

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -89,8 +89,8 @@ in
           homeConfigurations = mkOption {
             type = types.lazyAttrsOf types.unspecified;
             description = "All home manager configurations that should be considered for rekeying.";
-            default = lib.filterAttrs (_: x: x.config ? age) self.homeConfigurations;
-            defaultText = lib.literalExpression "lib.filterAttrs (_: x: x.config ? age) self.homeConfigurations";
+            default = lib.filterAttrs (_: x: x.config ? age) (self.homeConfigurations or { });
+            defaultText = lib.literalExpression "lib.filterAttrs (_: x: x.config ? age) (self.homeConfigurations or { })";
           };
 
           collectHomeManagerConfigurations = mkOption {


### PR DESCRIPTION
Fixes #111

Regression introduced in https://github.com/oddlama/agenix-rekey/commit/c4fd9281d31f8993635f39f04f3603b2d4fbf041

Side comment: should we also prepare for the (slow) migration from `{nixos,home}Configurations` -> `configurations.{nixos,home}` (same for `modules`)?