### PR TITLE
Add view subcommand

### DIFF
--- a/apps/view.nix
+++ b/apps/view.nix
@@ -1,0 +1,103 @@
+{ pkgs, ... }@inputs:
+let
+  inherit (pkgs.lib)
+    concatStringsSep
+    escapeShellArg
+    optionalString
+    ;
+
+  inherit (import ../nix/lib.nix inputs)
+    ageMasterDecrypt
+    validRelativeSecretPaths
+    ;
+
+in
+pkgs.writeShellScriptBin "agenix-view" ''
+  set -uo pipefail
+
+  function die() { echo "[1;31merror:[m $*" >&2; exit 1; }
+  function show_help() {
+    echo 'Usage: agenix view [OPTIONS] [FILE]'
+    echo 'Print age secret files tyo stdout with your master identity'
+    echo ""
+    echo 'OPTIONS:'
+    echo '-h, --help                Show help'
+    echo ""
+    echo 'FILE    An age-encrypted file to view.'
+    echo '          If not given, a fzf selector of used secrets will be shown.'
+  }
+
+  if [[ ! -e flake.nix ]] ; then
+    die "Please execute this script from your flake's root directory."
+  fi
+
+  POSITIONAL_ARGS=()
+  force=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      "help"|"--help"|"-help"|"-h")
+        show_help
+        exit 1
+        ;;
+      "--")
+        shift
+        POSITIONAL_ARGS+=("$@")
+        break
+        ;;
+      "-"*|"--"*) die "Invalid option '$1'" ;;
+      *) POSITIONAL_ARGS+=("$1") ;;
+    esac
+    shift
+  done
+
+  # If file is not given, show fzf
+  case "''${#POSITIONAL_ARGS[@]}" in
+    0)
+      ${optionalString (builtins.length validRelativeSecretPaths == 0) ''
+        die "No relevant secret definitions were found for any host."
+        break
+      ''}
+      FILE=$(echo ${escapeShellArg (concatStringsSep "\n" validRelativeSecretPaths)} \
+        | ${pkgs.fzf}/bin/fzf --preview "bash -c 'agenix view {1}'" --tiebreak=end --bind=tab:down,btab:up,change:top --height='~50%' --tac --cycle --layout=reverse) \
+        || die "No file selected. Aborting."
+    ;;
+    1) FILE="''${POSITIONAL_ARGS[0]}" ;;
+    *)
+      show_help
+      exit 1
+      ;;
+  esac
+  [[ "$FILE" != *".age" ]] && echo "[1;33mwarning:[m secrets should use the .age suffix by convention"
+
+  # Extract suffix before .age, if there is any.
+  SUFFIX=$(basename "$FILE")
+  SUFFIX=''${SUFFIX%.age}
+  if [[ "''${SUFFIX}" == *.* ]]; then
+    # Extract the second suffix if there is one
+    SUFFIX=''${SUFFIX##*.}
+  else
+    # Use txt otherwise
+    SUFFIX="txt"
+  fi
+
+  CLEARTEXT_FILE=$(${pkgs.coreutils}/bin/mktemp --suffix=".$SUFFIX")
+  ENCRYPTED_FILE=$(${pkgs.coreutils}/bin/mktemp --suffix=".$SUFFIX")
+
+  function cleanup() {
+    [[ -e "$CLEARTEXT_FILE" ]] && rm "$CLEARTEXT_FILE"
+    [[ -e "$ENCRYPTED_FILE" ]] && rm "$ENCRYPTED_FILE"
+  }; trap "cleanup" EXIT
+
+  if [[ -e "$FILE" ]]; then
+    ${ageMasterDecrypt} -o "$CLEARTEXT_FILE" "$FILE" \
+      || die "Failed to decrypt file. Aborting."
+  else
+    mkdir -p "$(dirname "$FILE")" \
+      || die "Could not create parent directory"
+  fi
+
+  cat "''${EDITOR_OPTS[@]}" "$CLEARTEXT_FILE" \
+    || die "Cat returned unsuccessful exit status. Aborting."
+
+  exit 0
+''

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -18,6 +18,7 @@ let
     ;
 
   allApps = [
+    "view"
     "edit"
     "generate"
     "rekey"

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
     inputs:
     let
       allApps = [
+        "view"
         "edit"
         "generate"
         "rekey"

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -11,11 +11,12 @@ writeShellScriptBin "agenix" ''
   function die() { echo "[1;31merror:[m $*" >&2; exit 1; }
   function show_help() {
     echo 'Usage: agenix <OPTIONS> [COMMAND]'
-    echo "Edit, generate or rekey secrets for agenix."
+    echo "View, edit, generate or rekey secrets for agenix."
     echo "Add help or --help to a subcommand to view a command specific help."
     echo ""
     echo 'COMMANDS:'
     echo '  rekey                   Re-encrypts secrets for hosts that require them.'
+    echo '  view                    Print age secret files to stdout with your master identity'
     echo '  edit                    Create/edit age secret files with $EDITOR and your master identity'
     echo '  generate                Automatically generates secrets that have generators'
     echo '  update-masterkeys       Update all stored secrets with a new set of masterkeys'
@@ -99,7 +100,9 @@ writeShellScriptBin "agenix" ''
     show_help
     exit 1
   fi
-  echo "Collecting information about hosts. This may take a while..."
+  if [[ "$APP" != "view" ]]; then
+    echo "Collecting information about hosts. This may take a while..."
+  fi
   exec nix run $SHOW_TRACE_ARG \
     ."$FLAKE_PARAMS"#agenix-rekey.${lib.escapeShellArg stdenv.hostPlatform.system}."$APP" \
      -- "''${PASS_THRU_ARGS[@]}"


### PR DESCRIPTION
In this change, the `edit` command was copied and adapted to have a 'simple' `view` command.
It shows the secret in fzf's preview pane if started with no path, and just prints the secret to stdout when a path is given.

I removed the display of the startup loading message for the view subcommand so as not to pollute fzf's preview. Maybe there is a better way to achieve this (like erasing the line when it stop being relevant, instead of not displaying at all)