### PR TITLE
Produce placeholder secret and don't rekey when hostPubkey is dummy

### DIFF
--- a/apps/rekey.nix
+++ b/apps/rekey.nix
@@ -80,6 +80,11 @@ let
         secret.rekeyFile != null
       );
     in
+    if hostCfg.config.age.rekey.hostPubkey == "age1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqs3290gq" then
+    ''
+      echo "[1;90m    Skipping[m [90m[dummy hostPubkey] "${escapeShellArg hostName}"[m"
+    ''
+    else
     {
       derivation =
         let


### PR DESCRIPTION
Allows for easier first deployment, without requiring an initial dummy rekeying.

See https://github.com/oddlama/agenix-rekey/issues/60