### PR TITLE
feat: add support for specialisations

### DIFF
--- a/nix/select-nodes.nix
+++ b/nix/select-nodes.nix
@@ -14,6 +14,7 @@ let
     foldl'
     optionalAttrs
     filterAttrs
+    concatMapAttrs
     ;
 
   effectiveNixosConfigurations =
@@ -29,18 +30,69 @@ let
     '' nodes)
     // nixosConfigurations;
 
+  # Extract specialisations from an attribute set of `nixosConfigurations` or `homeConfigurations`
+  # and add them along side the orignal configurations, using a `renamer` function that gets
+  # passed the name of the configuration and the specialisation to generate a new, unique name
+  # for each specialisation.
+  #
+  # Type:
+  # ```
+  # liftSpecialisationsRenamed :: (String -> String -> String) -> AttrSet -> AttrSet
+  # ```
+  liftSpecialisationsRenamed =
+    renamer:
+    concatMapAttrs (
+      baseName: baseCfg:
+      let
+        specialisations = mapAttrs' (
+          specName: specCfg:
+          nameValuePair (renamer baseName specName)
+            # Map specialisation configuration to its own { config = <...> } attrset,
+            # analogous to how homeConfigurations are handled further down.
+            { config = specCfg.configuration; }
+        ) baseCfg.config.specialisation;
+      in
+      { "${baseName}" = baseCfg; } // specialisations
+    );
+
+  nixosConfigurationsWithSpecialisations = liftSpecialisationsRenamed (
+    hostName: specName: "${hostName}:${specName}"
+  ) effectiveNixosConfigurations;
+
+  homeConfigurationsWithSpecialisations = liftSpecialisationsRenamed (
+    homeName: specName: "${homeName}:${specName}"
+  ) homeConfigurations;
+
   findHomeManagerForHost =
     hostName: hostCfg:
     if (hostCfg ? config.home-manager.users) then
-      mapAttrs' (name: value: nameValuePair "host-${hostName}-user-${name}" { config = value; }) (
+      mapAttrs' (name: value: nameValuePair "${hostName}:${name}" { config = value; }) (
         filterAttrs (_: value: value ? age.rekey) hostCfg.config.home-manager.users
       )
     else
       { };
 
-  listNixosConfigsWithHomeManager = mapAttrsToList findHomeManagerForHost effectiveNixosConfigurations;
+  listNixosConfigsWithHomeManager = mapAttrsToList findHomeManagerForHost nixosConfigurationsWithSpecialisations;
   hmConfigsInsideNixosConfiguration = foldl' lib.mergeAttrs { } listNixosConfigsWithHomeManager;
+
+  # Since `baseName` is derived from `nixosConfigurationsWithSpecialisations`,
+  # the names evaluate to "${hostName}:${homeName}:${specName}".
+  hmConfigsInsideNixosConfigurationWithSpecialisations = liftSpecialisationsRenamed (
+    baseName: specName: "${baseName}:${specName}"
+  ) hmConfigsInsideNixosConfiguration;
+
+  # Reduce probability of name collisions.
+  nixosConfigurationsRenamed = mapAttrs' (
+    n: v: nameValuePair "host: ${n}" v
+  ) nixosConfigurationsWithSpecialisations;
+  homeConfigurationsRenamed = mapAttrs' (
+    n: v: nameValuePair "home: ${n}" v
+  ) homeConfigurationsWithSpecialisations;
+  hmConfigsRenamed = mapAttrs' (
+    n: v: nameValuePair "host+home: ${n}" v
+  ) hmConfigsInsideNixosConfigurationWithSpecialisations;
+
 in
-effectiveNixosConfigurations
-// homeConfigurations
-// optionalAttrs collectHomeManagerConfigurations hmConfigsInsideNixosConfiguration
+nixosConfigurationsRenamed
+// homeConfigurationsRenamed
+// optionalAttrs collectHomeManagerConfigurations hmConfigsRenamed


### PR DESCRIPTION
Closes #120.

# Changes
Adds initial support for specialisations by treating them as separate configurations during generation and rekeying operations.
Both NixOS and Home Manager specialisations are supported.
Users of existing configurations should see no changes in usage, it should all just work™.

# Notes/Limitations
- Since the specialisations are treated as separate configurations, they require separate values of `localStorageDir`.
  Otherwise the generated secrets will be immediately garbage collected as orphaned secrets.
  For the same reason, there is no deduplication of secrets between the different specialisations.
- The current implementation makes some effort to avoid name collisions between configurations and specialisations.
  However, if e.g. a configuration with the name `foo:bar` exists and a separate configuration with the name `foo` and a specialisation `bar` exists as well, one will likely overwrite the other and rekeying will not work as expected, if at all.

# Testing
A minimal flake that provides a usage example and some basic test cases can be found [here](https://github.com/Lukas-C/agenix-rekey_specialization-test).
My personal config that uses the derivation storage mode also appears to work with the implementation.

# Todo
- [ ] Documentation: Add a short section about specialisations, how they basically behave like configurations and are as such subject to the same limitations, e.g. needing separate `localStorageDir`s. A note about the name collision issue above may also be not a bad idea.