### PR TITLE
fix: do not rekey intermediary secrets for hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,8 +487,8 @@ This can be easier to deal with than lists in some cases.
 ```
 
 Secrets that only serve as input to further generators can be marked as intermediary by setting the same-named attribute to `true`.
-On the host, they are then replaced by dummy files, i.e., the secret itself is not decrypted.
-This is especially useful, if consumers of the secret only need a hash of a password which you are generating in a second secret: by setting `intermediary = true`, the password itself is not visible on the deployed system.
+These secrets are not rekeyed for the host (i.e., not encrypted with the host's key), and on the host they are replaced by dummy files.
+This is especially useful if consumers of the secret only need a hash of a password which you are generating in a second secret: by setting `intermediary = true`, the password itself cannot be decrypted on the deployed system, even by a root user with access to the host's private key.
 
 ```nix
 {
@@ -594,8 +594,11 @@ you should always use this option instead of `file`.
 | Default | `false` |
 | Example | `true` |
 
-Whether the secret is only required as an intermediary/repository secret and 
-should not be uploaded and decrypted on the host.
+Whether the secret is only required as an intermediary/repository secret and
+should not be rekeyed or decrypted on the host. Intermediary secrets are not
+encrypted with the host's key, ensuring they cannot be decrypted even by a root
+user with access to the host's private key. A dummy file is placed on the host
+to satisfy agenix.
 
 ## `age.secrets.<name>.generator`
 

--- a/apps/rekey.nix
+++ b/apps/rekey.nix
@@ -77,7 +77,7 @@ let
         assert assertMsg (
           secret.rekeyFile != null -> builtins.pathExists secret.rekeyFile
         ) "age.secrets.${name}.rekeyFile ([33m${toString secret.rekeyFile}[m) doesn't exist. ${hint}";
-        secret.rekeyFile != null
+        secret.rekeyFile != null && !secret.intermediary
       );
     in
     if

--- a/modules/agenix-rekey.nix
+++ b/modules/agenix-rekey.nix
@@ -348,7 +348,11 @@ in
               default = false;
               description = ''
                 Whether the secret is only required as an intermediary/repository
-                secret and should not be uploaded and decrypted on the host.
+                secret and should not be rekeyed or decrypted on the host.
+                Intermediary secrets are not encrypted with the host's key,
+                ensuring they cannot be decrypted even by a root user with
+                access to the host's private key. A dummy file is placed on
+                the host to satisfy agenix.
               '';
             };
 

--- a/nix/output-derivation.nix
+++ b/nix/output-derivation.nix
@@ -28,7 +28,7 @@ let
     assert assertMsg (
       secret.rekeyFile != null -> builtins.pathExists secret.rekeyFile
     ) "age.secrets.${name}.rekeyFile ([33m${toString secret.rekeyFile}[m) doesn't exist. ${hint}";
-    secret.rekeyFile != null
+    secret.rekeyFile != null && !secret.intermediary
   );
 
   # Returns a bash expression that refers to the path where a particular


### PR DESCRIPTION
Previously, intermediary secrets were rekeyed (encrypted with the host's key) even though they were only deployed as dummy files. This created a security risk: a root user on the host with access to the git repository could decrypt them using the host's private key.

Now, intermediary secrets are excluded from rekeying entirely.

Fixes #132