### PR TITLE
feat: Add extraConfigurations option to support user extension types

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -39,6 +39,7 @@ in
                   nixosConfigurations
                   darwinConfigurations
                   homeConfigurations
+                  extraConfigurations
                   collectHomeManagerConfigurations
                   ;
                 inherit (config'.agenix-rekey.pkgs) lib;
@@ -99,6 +100,14 @@ in
             description = "All home manager configurations that should be considered for rekeying.";
             default = lib.filterAttrs (_: x: x.config ? age) (self.homeConfigurations or { });
             defaultText = lib.literalExpression "lib.filterAttrs (_: x: x.config ? age) (self.homeConfigurations or { })";
+          };
+
+          # Fork extension: support for custom configurations
+          extraConfigurations = mkOption {
+            type = types.lazyAttrsOf types.unspecified;
+            description = "Custom configurations (nixidy, terranix, etc) that should be considered for rekeying.";
+            default = self.extraConfigurations or { };
+            defaultText = lib.literalExpression "lib.filterAttrs (_: x: x.config ? age) (self.extraConfigurations or { })";
           };
 
           collectHomeManagerConfigurations = mkOption {

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,9 @@
               nixosConfigurations ? { },
               darwinConfigurations ? { },
               homeConfigurations ? { },
+              # Generic support for custom configurations (fork extension)
+              # Supports nixidy, terranix, or any config with module system
+              extraConfigurations ? { },
               collectHomeManagerConfigurations ? true,
               # Legacy alias for nixosConfigurations see https://github.com/oddlama/agenix-rekey/pull/51
               nodes ? { },
@@ -110,6 +113,7 @@
                       nixosConfigurations
                       darwinConfigurations
                       homeConfigurations
+                      extraConfigurations
                       collectHomeManagerConfigurations
                       ;
                     inherit (pkgs') lib;

--- a/modules/agenix-rekey.nix
+++ b/modules/agenix-rekey.nix
@@ -37,7 +37,7 @@ let
     types
     ;
 
-  target = (import ../nix/target-name.nix) { inherit config; };
+  target = config.age.rekey.recipientIdentifier;
   # This pubkey is just binary 0x01 in each byte, so you can be sure there is no known private key for this
   dummyPubkey = "age1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqs3290gq";
   isAbsolutePath = x: substring 0 1 x == "/";
@@ -107,7 +107,7 @@ let
             (listOf unspecified)
             (attrsOf unspecified)
           ];
-        example = literalExpression ''[ config.age.secrets.basicAuthPw1 nixosConfigurations.machine2.config.age.secrets.basicAuthPw ]'';
+        example = literalExpression "[ config.age.secrets.basicAuthPw1 nixosConfigurations.machine2.config.age.secrets.basicAuthPw ]";
         default = [ ];
         description = ''
           Other secrets on which this secret depends. This guarantees that in the final
@@ -448,6 +448,20 @@ in
     };
 
     rekey = {
+      recipientIdentifier = mkOption {
+        type = types.str;
+        default =
+          config.networking.hostName or (config.home.username
+            or (throw "age.rekey.recipientIdentifier must be set for this configuration type")
+          );
+        description = ''
+          The identifier for this recipient used in derivation names and default storage paths.
+
+          Defaults to the hostname for NixOS configurations or the username for
+          home-manager configurations. Must be explicitly set for other configuration types.
+        '';
+      };
+
       secretsDir = mkOption {
         type = types.nullOr types.path;
         default = null;

--- a/nix/output-derivation.nix
+++ b/nix/output-derivation.nix
@@ -11,9 +11,7 @@ let
     filterAttrs
     flip
     ;
-  target = (import ./target-name.nix) {
-    config = hostConfig;
-  };
+  target = hostConfig.age.rekey.recipientIdentifier;
 
   # All secrets that have rekeyFile set. These will be rekeyed.
   secretsToRekey = flip filterAttrs hostConfig.age.secrets (

--- a/nix/select-nodes.nix
+++ b/nix/select-nodes.nix
@@ -4,6 +4,8 @@
   nixosConfigurations,
   darwinConfigurations,
   homeConfigurations,
+  # Fork extension: support for custom configurations (nixidy, terranix, etc)
+  extraConfigurations ? { },
   collectHomeManagerConfigurations,
   ...
 }:
@@ -39,6 +41,8 @@ let
 
   prefixedNixosConfigurations = prefixHosts "nixos" effectiveNixosConfigurations;
   prefixedDarwinConfigurations = prefixHosts "darwin" darwinConfigurations;
+  # Fork extension: prefix custom configurations with "extra:"
+  prefixedExtraConfigurations = prefixHosts "extra" extraConfigurations;
 
   findHomeManagerForHost =
     hostName: hostCfg:
@@ -49,7 +53,8 @@ let
     else
       { };
 
-  effectiveHostConfigurations = prefixedNixosConfigurations // prefixedDarwinConfigurations;
+  effectiveHostConfigurations =
+    prefixedNixosConfigurations // prefixedDarwinConfigurations // prefixedExtraConfigurations;
   listHostConfigsWithHomeManager = mapAttrsToList findHomeManagerForHost effectiveHostConfigurations;
   hmConfigsInsideHostConfiguration = foldl' lib.mergeAttrs { } listHostConfigsWithHomeManager;
 

--- a/nix/target-name.nix
+++ b/nix/target-name.nix
@@ -1,5 +1,0 @@
-{ config }:
-let
-  isNixosConfiguration = config ? networking.hostName;
-in
-if isNixosConfiguration then config.networking.hostName else config.home.username


### PR DESCRIPTION
## Add support for custom configurations via `extraConfigurations`

This PR adds generic support for custom Nix-based configurations beyond NixOS, Darwin, and home-manager.

### Motivation

Currently, agenix-rekey only supports NixOS, Darwin, and home-manager configurations. However, there are other Nix-based configuration systems in the ecosystem that could benefit from agenix-rekey's secret management:

- [nixidy](https://github.com/arnarg/nixidy) - Kubernetes manifest generation
- [terranix](https://github.com/terranix/terranix) - Terraform configuration generation
- Custom configuration systems using NixOS module system

This PR introduces a minimal, generic extension point that enables these use cases without adding complexity to the core.

### Changes

#### 1. New `extraConfigurations` parameter

Added a new `extraConfigurations` parameter to the `configure()` function and flake module that accepts any configuration with:
- A module system supporting `config.age.*` options
- The agenix-rekey module imported

**Files modified:**
- `flake.nix` - Added parameter to `configure()` function
- `flake-module.nix` - Added option with appropriate defaults
- `nix/select-nodes.nix` - Process and prefix configurations with `extra:` namespace

#### 2. New `age.rekey.recipientIdentifier` option

Replaced the hardcoded target name logic with an explicit module option:

```nix
age.rekey.recipientIdentifier = mkOption {
  type = types.str;
  default =
    config.networking.hostName or (
      config.home.username or (
        throw "age.rekey.recipientIdentifier must be set for this configuration type"
      )
    );
  description = ''
    The identifier for this recipient used in derivation names and default storage paths.

    Defaults to the hostname for NixOS configurations or the username for
    home-manager configurations. Must be explicitly set for other configuration types.
  '';
};
```

**Benefits:**
- Makes the identifier explicit and configurable
- Provides clear error messages for unsupported configuration types
- Enables custom configurations to set their own identifier

**Files modified:**
- `modules/agenix-rekey.nix` - Added option and updated to use it
- `nix/output-derivation.nix` - Updated to use new option
- `nix/target-name.nix` - **Removed** (logic moved to module option)

### Usage Example

```nix
{
  inputs = {
    agenix-rekey.url = "github:oddlama/agenix-rekey";
    nixidy.url = "github:arnarg/nixidy";
  };

  outputs = { self, agenix-rekey, nixidy, ... }: {
    # Define a custom configuration
    extraConfigurations.production = nixidy.lib.mkEnv {
      modules = [
        agenix-rekey.nixosModules.default
        {
          age = {
            rekey = {
              recipientIdentifier = "prod-cluster";
              masterIdentities = [ ./keys/master.pub ];
            };
            secrets.api-key = {
              rekeyFile = ./secrets/api-key.age;
            };
          };
        }
      ];
    };

    # Configure agenix-rekey with custom configurations
    agenix-rekey = agenix-rekey.configure {
      userFlake = self;
      nixosConfigurations = self.nixosConfigurations;
      extraConfigurations = self.extraConfigurations;
    };
  };
}
```

### Compatibility

- ✅ **Backward compatible** - No changes to existing NixOS/Darwin/home-manager workflows
- ✅ **Optional** - `extraConfigurations` defaults to `{ }` if not provided
- ✅ **Non-breaking** - All existing configurations continue to work identically

### Testing

Tested with:
- Existing NixOS configurations (no regression)
- Custom nixidy configurations with SOPS output generation
- Explicit `recipientIdentifier` setting for custom types
