### PR TITLE
feat: add requiredSystemFeatures option for rekeying derivation

### DIFF
--- a/modules/agenix-rekey.nix
+++ b/modules/agenix-rekey.nix
@@ -544,6 +544,18 @@ in
         '';
       };
 
+      requiredSystemFeatures = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = ''
+          Additional requiredSystemFeatures to set on the rekeying derivation.
+          Useful for ensuring the derivation is only built on machines that
+          have access to hardware tokens (e.g. YubiKeys) by setting this to
+          [ "yubikey" ] and advertising the feature only on machines with
+          the token attached.
+        '';
+      };
+
       localStorageDir = mkOption {
         type = types.path;
         example = literalExpression ''./. /* <- flake root */ + "/secrets/rekeyed/myhost" /* separate folder for each host */'';

--- a/nix/output-derivation.nix
+++ b/nix/output-derivation.nix
@@ -48,6 +48,8 @@ appHostPkgs.stdenv.mkDerivation {
   name = "agenix-rekey-host-secrets";
   description = "Rekeyed secrets for ${target}";
 
+  inherit (hostConfig.age.rekey) requiredSystemFeatures;
+
   # No special inputs are necessary.
   dontUnpack = true;
   dontPatch = true;


### PR DESCRIPTION
# Description:
This adds a requiredSystemFeatures option to age.rekey that gets passed through to the rekeying derivation in output-derivation.nix.
# Motivation
When using storageMode = "derivation" with remote builders, the rekeying derivation can get dispatched to a remote machine that doesn't have access to the hardware token (e.g. YubiKey) needed to build it. Even if you've already run agenix rekey locally, nix flake check or nixos-rebuild may still send the derivation to a remote builder which then fails.
By setting requiredSystemFeatures = [ "yubikey" ] (or any custom feature) and advertising that feature only on machines with the hardware token, Nix's scheduler is constrained to only build the rekeying derivation on machines that actually have access to the token.

I have tested this locally and it seems to work