### PR TITLE
Fix dummy key generation when using plugins

### DIFF
--- a/modules/agenix-rekey.nix
+++ b/modules/agenix-rekey.nix
@@ -54,18 +54,29 @@ let
 
   # A decryptable dummy secret that is used as a replacement when a secret specifies `intermediary = true`.
   pubkeyOpt = x: if isAbsolutePath x then "-R ${escapeShellArg x}" else "-r ${escapeShellArg x}";
-  dummySecret = pkgs.runCommand "generate-dummy-secret-${target}.age" { } ''
-    ${getExe pkgs.rage} -e ${pubkeyOpt (removeSuffix "\n" config.age.rekey.hostPubkey)} -o "$out" <<EOF
-    # This is a dummy secret.
-    # It was placed here because the original secret is an intermediary secret.
-    EOF
-  '';
-  placeholderSecret = pkgs.runCommand "generate-placeholder-secret-${target}.age" { } ''
-    ${getExe pkgs.rage} -e ${pubkeyOpt (removeSuffix "\n" config.age.rekey.hostPubkey)} -o "$out" <<EOF
-    # This is a placeholder secret.
-    # It was placed here because the host public key is of a dummy (placeholder) value.
-    EOF
-  '';
+  dummySecret =
+    pkgs.runCommand "generate-dummy-secret-${target}.age"
+      {
+        nativeBuildInputs = [ pkgs.age ] ++ config.age.rekey.agePlugins;
+      }
+      ''
+        ${getExe pkgs.rage} -e ${pubkeyOpt (removeSuffix "\n" config.age.rekey.hostPubkey)} -o "$out" <<EOF
+        # This is a dummy secret.
+        # It was placed here because the original secret is an intermediary secret.
+        EOF
+      '';
+
+  placeholderSecret =
+    pkgs.runCommand "generate-placeholder-secret-${target}.age"
+      {
+        nativeBuildInputs = [ pkgs.age ] ++ config.age.rekey.agePlugins;
+      }
+      ''
+        ${getExe pkgs.rage} -e ${pubkeyOpt (removeSuffix "\n" config.age.rekey.hostPubkey)} -o "$out" <<EOF
+        # This is a placeholder secret.
+        # It was placed here because the host public key is of a dummy (placeholder) value.
+        EOF
+      '';
 
   rekeyedLocalSecret =
     secret:
@@ -107,7 +118,7 @@ let
             (listOf unspecified)
             (attrsOf unspecified)
           ];
-        example = literalExpression ''[ config.age.secrets.basicAuthPw1 nixosConfigurations.machine2.config.age.secrets.basicAuthPw ]'';
+        example = literalExpression "[ config.age.secrets.basicAuthPw1 nixosConfigurations.machine2.config.age.secrets.basicAuthPw ]";
         default = [ ];
         description = ''
           Other secrets on which this secret depends. This guarantees that in the final


### PR DESCRIPTION
Closes #154 by passing both `age` (which contains the missing `age-plugin-tag`) and, to be on the safe side, any other configured plugins, in the build inputs of the dummy generator.

Tested successfully.

I didn't change the quotes in the last line of the diff. That was done by `treefmt`.