### PR TITLE
Add command-scoped master identity sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1006,6 +1006,12 @@ the command. Identity formats whose cryptographic salt changes per file may
 still require one touch per file. At most one distinct wrapper may be selected
 across the configurations passed to `agenix-rekey.configure`.
 
+Before either batch command enters the wrapper, it prints the complete operation
+plan. `agenix rekey` shows every host and secret target, files that are already
+current, orphan removals, Git staging, and any store deletion or realization.
+`agenix update-masterkeys` lists every source file whose master recipients will
+be updated. Help and path-inspection commands do not start a session.
+
 # ⌨ Environment variables
 
 ## `AGENIX_REKEY_PRIMARY_IDENTITY`

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ and will provide you with a smooth rekeying experience. In summary, you get:
 To function properly, agenix-rekey has to do some nix gymnastics. You can read more about [how it works](#how-does-it-work) below. Remarks:
 
 - Since `age-plugin-yubikey` 0.4.0 the PIN is required only once. Using a password protected master key will never
-  have this benefit, and the password will alwas be required for each rekeying operation.
-  There's no way around that without caching the key, which I didn't want to do.
+  have this benefit, and the password will always be required for each rekeying operation.
+  Hardware plugins that provide an explicit command-scoped session can reuse their
+  derived key for a batch without writing it to disk.
 
 ## Overview
 
@@ -980,6 +981,30 @@ A list of plugins that should be available to rage while rekeying.
 They will be added to the PATH with lowest-priority before rage is invoked,
 meaning if you have the plugin installed on your system, that one is preferred
 in an effort to not break complex setups (e.g. WSL passthrough).
+
+## `age.rekey.masterIdentitySessionWrapper`
+
+| Type    | `nullOr package` |
+|-----|-----|
+| Default | `null` |
+| Example | `pkgs.age-plugin-fido2-hmac-session` |
+
+An optional wrapper for the batch commands `agenix rekey` and
+`agenix update-masterkeys`. It is invoked as:
+
+```console
+<wrapper> -- <agenix-command> [args...]
+```
+
+This is intended for hardware-backed plugins that can keep a derived identity
+in locked memory for one command. It allows multiple source files to be
+processed after one physical-presence check, while avoiding a software identity
+on disk. The wrapper must clear its state when the command exits.
+
+The guarantee is one touch per distinct identity that is actually used during
+the command. Identity formats whose cryptographic salt changes per file may
+still require one touch per file. At most one distinct wrapper may be selected
+across the configurations passed to `agenix-rekey.configure`.
 
 # ⌨ Environment variables
 

--- a/apps/rekey.nix
+++ b/apps/rekey.nix
@@ -33,7 +33,8 @@ let
       ''
         if [[ "''${AGENIX_REKEY_MASTER_IDENTITY_SESSION_ACTIVE:-}" != true ]]; then
           export AGENIX_REKEY_MASTER_IDENTITY_SESSION_ACTIVE=true
-          exec ${pkgs.lib.getExe masterIdentitySessionWrapper} -- "$0" "$@"
+          export AGENIX_REKEY_INTERNAL_OPERATION_PLAN_SHOWN=true
+          exec ${pkgs.lib.getExe masterIdentitySessionWrapper} -- "$0" "''${ORIGINAL_ARGS[@]}"
         fi
       '';
 
@@ -73,8 +74,8 @@ let
     ) nodes
   );
 
-  rekeyCommandsForHost =
-    hostName: hostCfg:
+  secretsToRekeyFor =
+    hostCfg:
     let
       # All secrets that have rekeyFile set. These will be rekeyed.
       secretsToRekey = flip filterAttrs hostCfg.config.age.secrets (
@@ -92,6 +93,123 @@ let
         secret.rekeyFile != null && !secret.intermediary
       );
     in
+    secretsToRekey;
+
+  operationPlanForHost =
+    hostName: hostCfg:
+    let
+      secretsToRekey = secretsToRekeyFor hostCfg;
+    in
+    if
+      hostCfg.config.age.rekey.hostPubkey
+      == "age1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqs3290gq"
+    then
+      ''
+        printf '  Host %s\n' ${escapeShellArg hostName}
+        echo '    skip host: dummy host public key'
+      ''
+    else
+      {
+        derivation =
+          let
+            rekeyedSecrets = derivationFor hostCfg;
+            outPath = escapeShellArg (outPathFor hostCfg);
+            drvPath = escapeShellArg (drvPathFor hostCfg);
+            planSecret =
+              secretName: secret:
+              let
+                secretOut = rekeyedSecrets.cachePathFor secret;
+              in
+              ''
+                if [[ -e ${secretOut} ]] && [[ "$FORCE" != true ]]; then
+                  printf '    keep %s: already rekeyed\n' ${escapeShellArg secretName}
+                else
+                  printf '    rekey %s: %s -> %s\n' ${
+                    escapeShellArgs [
+                      secretName
+                      secret.rekeyFile
+                      secretOut
+                    ]
+                  }
+                  planned_rekey=true
+                fi
+              '';
+          in
+          ''
+            printf '  Host %s (derivation storage)\n' ${escapeShellArg hostName}
+            planned_delete=false
+            if [[ -e ${outPath} && ( "$FORCE" == true || ! -e ${outPath}/success ) ]]; then
+              printf '    delete store path: %s\n' ${outPath}
+              planned_delete=true
+            fi
+            planned_rekey=false
+            ${concatStringsSep "\n" (mapAttrsToList planSecret secretsToRekey)}
+            if [[ "$planned_rekey" == true || ! -e ${outPath} || "$planned_delete" == true ]]; then
+              printf '    realize derivation: %s\n' ${drvPath}
+            fi
+          '';
+        local =
+          let
+            relativeToFlake =
+              filePath:
+              let
+                fileStr = builtins.unsafeDiscardStringContext (toString filePath);
+              in
+              if hasPrefix userFlakeDir fileStr then
+                "." + removePrefix userFlakeDir fileStr
+              else
+                throw "Cannot determine true origin of ${fileStr} which doesn't seem to be a direct subpath of the flake directory ${userFlakeDir}. Did you make sure to specify `age.rekey.localStorageDir` relative to the root of your flake?";
+
+            hostRekeyDir = relativeToFlake hostCfg.config.age.rekey.localStorageDir;
+            planSecret =
+              secretName: secret:
+              let
+                pubkeyHash = builtins.hashString "sha256" hostCfg.config.age.rekey.hostPubkey;
+                identHash = builtins.substring 0 32 (
+                  builtins.hashString "sha256" (pubkeyHash + builtins.hashFile "sha256" secret.rekeyFile)
+                );
+                secretOut = "${hostRekeyDir}/${identHash}-${secret.name}.age";
+              in
+              ''
+                PLAN_TRACKED_SECRETS[${escapeShellArg secretOut}]=true
+                if [[ -e ${escapeShellArg secretOut} ]] && [[ "$FORCE" != true ]]; then
+                  printf '    keep %s: already rekeyed\n' ${escapeShellArg secretName}
+                else
+                  printf '    rekey %s: %s -> %s\n' ${
+                    escapeShellArgs [
+                      secretName
+                      secret.rekeyFile
+                      secretOut
+                    ]
+                  }
+                fi
+              '';
+          in
+          ''
+            printf '  Host %s (local storage)\n' ${escapeShellArg hostName}
+            printf '    ensure output directory: %s\n' ${escapeShellArg hostRekeyDir}
+            unset PLAN_TRACKED_SECRETS
+            declare -A PLAN_TRACKED_SECRETS=()
+            ${concatStringsSep "\n" (mapAttrsToList planSecret secretsToRekey)}
+            if [[ -d ${escapeShellArg hostRekeyDir} ]]; then
+              while IFS= read -r -d $'\0' f; do
+                if [[ "''${PLAN_TRACKED_SECRETS["$f"]-false}" == false ]]; then
+                  printf '    remove orphan: %s\n' "$f"
+                fi
+              done < <(find ${escapeShellArg hostRekeyDir} -type f -print0)
+            fi
+            if [[ "$ADD_TO_GIT" == true && "''${#PLAN_TRACKED_SECRETS[@]}" -gt 0 ]]; then
+              printf '    stage output directory in git: %s\n' ${escapeShellArg hostRekeyDir}
+            fi
+          '';
+      }
+      .${hostCfg.config.age.rekey.storageMode};
+
+  rekeyCommandsForHost =
+    hostName: hostCfg:
+    let
+      secretsToRekey = secretsToRekeyFor hostCfg;
+    in
     if
       hostCfg.config.age.rekey.hostPubkey
       == "age1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqs3290gq"
@@ -103,14 +221,9 @@ let
       {
         derivation =
           let
-            # The derivation containing the resulting rekeyed secrets
             rekeyedSecrets = derivationFor hostCfg;
-
-            # The resulting store path for this host's rekeyed secrets
             outPath = escapeShellArg (outPathFor hostCfg);
-            # The builder which we can use to realise the derivation
             drvPath = escapeShellArg (drvPathFor hostCfg);
-
             rekeyCommand =
               secretName: secret:
               let
@@ -121,7 +234,6 @@ let
                   echo "[1;90m    Skipping[m [90m[already rekeyed] "${escapeShellArg hostName}":"${escapeShellArg secretName}"[m"
                 else
                   echo "[1;32m    Rekeying[m [90m"${escapeShellArg hostName}":[34m"${escapeShellArg secretName}"[m"
-                  # Don't escape the out path as it could contain variables we want to expand
                   if reencrypt "${secretOut}" ${
                     escapeShellArgs [
                       secret.rekeyFile
@@ -137,14 +249,12 @@ let
               '';
           in
           ''
-            # Called in `reencrypt`
             function encrypt() {
               ${ageHostEncrypt hostCfg} "$@"
             }
 
             ANY_DERIVATION_MODE_HOSTS=true
             will_delete=false
-            # Remove any existing rekeyed secrets from the nix store if --force was given
             if [[ -e ${outPath} && ( "$FORCE" == true || ! -e ${outPath}/success ) ]]; then
               echo "[1;31m     Marking[m [31mexisting store path of [33m"${escapeShellArg hostName}"[31m for deletion [90m("${outPath}")[m"
               STORE_PATHS_TO_DELETE+=(${outPath})
@@ -152,12 +262,9 @@ let
             fi
 
             any_rekeyed=false
-            # Rekey secrets for ${hostName}
             mkdir -p ${rekeyedSecrets.cacheDir}/secrets
             ${concatStringsSep "\n" (mapAttrsToList rekeyCommand secretsToRekey)}
 
-            # We need to save the rekeyed output when any secret was rekeyed, or when the
-            # output derivation doesn't exist (it could have been removed manually).
             if [[ "$any_rekeyed" == true || ! -e ${outPath} || "$will_delete" == true ]]; then
               SANDBOX_PATHS[${rekeyedSecrets.cacheDir}]=1
               [[ ${rekeyedSecrets.cacheDir} =~ [[:space:]] ]] \
@@ -188,7 +295,6 @@ let
                 secretOut = "${hostRekeyDir}/${identHash}-${secret.name}.age";
               in
               ''
-                # Mark secret as known
                 TRACKED_SECRETS[${escapeShellArg secretOut}]=true
 
                 if [[ -e ${escapeShellArg secretOut} ]] && [[ "$FORCE" != true ]]; then
@@ -209,20 +315,16 @@ let
               '';
           in
           ''
-            # Called in `reencrypt`
             function encrypt() {
               ${ageHostEncrypt hostCfg} "$@"
             }
 
-            # Create a set of tracked secrets so we can remove orphaned files afterwards
             unset TRACKED_SECRETS
-            declare -A TRACKED_SECRETS=() # the `=()` is required otherwise accessing the length fails with `unbound variable` 
+            declare -A TRACKED_SECRETS=()
 
-            # Rekey secrets for ${hostName}
             mkdir -p ${hostRekeyDir}
             ${concatStringsSep "\n" (mapAttrsToList rekeyCommand secretsToRekey)}
 
-            # Remove orphaned files
             REMOVED_ORPHANS=0
             (
               shopt -s nullglob
@@ -260,7 +362,7 @@ in
 pkgs.writeShellScriptBin "agenix-rekey" ''
   set -euo pipefail
 
-  ${masterIdentitySessionPrelude}
+  ORIGINAL_ARGS=("$@")
 
   export PATH="''${PATH:+"''${PATH}:"}"${escapeShellArg binPath}
 
@@ -373,6 +475,21 @@ pkgs.writeShellScriptBin "agenix-rekey" ''
   if [[ ! -e flake.nix ]] ; then
     die "Please execute this script from your flake's root directory."
   fi
+
+  if [[ "''${AGENIX_REKEY_MASTER_IDENTITY_SESSION_ACTIVE:-}" != true || "''${AGENIX_REKEY_INTERNAL_OPERATION_PLAN_SHOWN:-}" != true ]]; then
+    echo 'Planned operations:'
+    ${
+      if masterIdentitySessionWrapper == null then
+        ""
+      else
+        "echo '  Use one command-scoped master identity session.'"
+    }
+    ${concatStringsSep "\n" (mapAttrsToList operationPlanForHost nodes)}
+    echo 'End of plan.'
+    echo
+  fi
+
+  ${masterIdentitySessionPrelude}
 
   dummy_all=0
   function flush_stdin() {

--- a/apps/rekey.nix
+++ b/apps/rekey.nix
@@ -23,7 +23,19 @@ let
     userFlakeDir
     ageHostEncrypt
     ageMasterDecrypt
+    masterIdentitySessionWrapper
     ;
+
+  masterIdentitySessionPrelude =
+    if masterIdentitySessionWrapper == null then
+      ""
+    else
+      ''
+        if [[ "''${AGENIX_REKEY_MASTER_IDENTITY_SESSION_ACTIVE:-}" != true ]]; then
+          export AGENIX_REKEY_MASTER_IDENTITY_SESSION_ACTIVE=true
+          exec ${pkgs.lib.getExe masterIdentitySessionWrapper} -- "$0" "$@"
+        fi
+      '';
 
   # The derivation containing the resulting rekeyed secrets for
   # the given host configuration
@@ -247,6 +259,8 @@ let
 in
 pkgs.writeShellScriptBin "agenix-rekey" ''
   set -euo pipefail
+
+  ${masterIdentitySessionPrelude}
 
   export PATH="''${PATH:+"''${PATH}:"}"${escapeShellArg binPath}
 

--- a/apps/update-masterkeys.nix
+++ b/apps/update-masterkeys.nix
@@ -3,11 +3,25 @@ let
   inherit (import ../nix/lib.nix inputs)
     ageMasterEncrypt
     ageMasterDecrypt
+    masterIdentitySessionWrapper
     validRelativeSecretPaths
     ;
+
+  masterIdentitySessionPrelude =
+    if masterIdentitySessionWrapper == null then
+      ""
+    else
+      ''
+        if [[ "''${AGENIX_REKEY_MASTER_IDENTITY_SESSION_ACTIVE:-}" != true ]]; then
+          export AGENIX_REKEY_MASTER_IDENTITY_SESSION_ACTIVE=true
+          exec ${pkgs.lib.getExe masterIdentitySessionWrapper} -- "$0" "$@"
+        fi
+      '';
 in
 pkgs.writeShellScriptBin "agenix-update-masterkeys" ''
   set -uo pipefail
+
+  ${masterIdentitySessionPrelude}
 
   function die() { echo "[1;31merror:[m $*" >&2; exit 1; }
   function show_help() {

--- a/apps/update-masterkeys.nix
+++ b/apps/update-masterkeys.nix
@@ -14,24 +14,63 @@ let
       ''
         if [[ "''${AGENIX_REKEY_MASTER_IDENTITY_SESSION_ACTIVE:-}" != true ]]; then
           export AGENIX_REKEY_MASTER_IDENTITY_SESSION_ACTIVE=true
-          exec ${pkgs.lib.getExe masterIdentitySessionWrapper} -- "$0" "$@"
+          export AGENIX_REKEY_INTERNAL_OPERATION_PLAN_SHOWN=true
+          exec ${pkgs.lib.getExe masterIdentitySessionWrapper} -- "$0" "''${ORIGINAL_ARGS[@]}"
         fi
       '';
 in
 pkgs.writeShellScriptBin "agenix-update-masterkeys" ''
   set -uo pipefail
 
-  ${masterIdentitySessionPrelude}
+  ORIGINAL_ARGS=("$@")
 
   function die() { echo "[1;31merror:[m $*" >&2; exit 1; }
   function show_help() {
-    echo 'Usage: agenix update-masterkeys'
+    echo 'Usage: agenix update-masterkeys [OPTIONS]'
     echo 'Update all stored secrets with a new set of masterkeys.'
+    echo
+    echo 'OPTIONS:'
+    echo '-h, --help    Show help'
   }
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      "help"|"--help"|"-help"|"-h")
+        show_help
+        exit 0
+        ;;
+      *) die "Invalid option '$1'" ;;
+    esac
+  done
 
   if [[ ! -e flake.nix ]] ; then
     die "Please execute this script from your flake's root directory."
   fi
+
+  if [[ "''${AGENIX_REKEY_MASTER_IDENTITY_SESSION_ACTIVE:-}" != true || "''${AGENIX_REKEY_INTERNAL_OPERATION_PLAN_SHOWN:-}" != true ]]; then
+    echo 'Planned operations:'
+    ${
+      if masterIdentitySessionWrapper == null then
+        ""
+      else
+        "echo '  Use one command-scoped master identity session.'"
+    }
+    echo '  Update master-key recipients for these files:'
+    ${
+      if validRelativeSecretPaths == [ ] then
+        "echo '    (none)'"
+      else
+        builtins.concatStringsSep "\n" (
+          builtins.map (path: "printf '    %s\\n' ${pkgs.lib.escapeShellArg path}") validRelativeSecretPaths
+        )
+    }
+    echo '  Each file will be decrypted, re-encrypted for the configured master recipients,'
+    echo '  and replaced only after re-encryption succeeds.'
+    echo 'End of plan.'
+    echo
+  fi
+
+  ${masterIdentitySessionPrelude}
 
   ${builtins.concatStringsSep "" (
     builtins.map (

--- a/modules/agenix-rekey.nix
+++ b/modules/agenix-rekey.nix
@@ -81,13 +81,11 @@ let
         else
           "Have you added it to git?";
 
-      # Use builtins.path to make sure that we have a standalone copy of the subdirectory in the store.
-      # This is important to ensure that the path only changes if there are actual changes to this
-      # directory. If we were still using userFlake.outPath + "/secrets/[...]" or something similar,
-      # then the path would change on each subsequent build because the flake path changes.
-      rekeyedDir = builtins.path { path = config.age.rekey.localStorageDir; };
-      rekeyedPath =
-        builtins.seq (builtins.readDir rekeyedDir) (rekeyedDir + "/${identHash}-${secret.name}.age");
+      # The flake supplies localStorageDir from its immutable source path. Do
+      # not create a second lazy builtins.path snapshot here: during a full
+      # flake evaluation that copy can be probed before its store path is
+      # realized, making checks depend on configuration traversal order.
+      rekeyedPath = config.age.rekey.localStorageDir + "/${identHash}-${secret.name}.age";
     in
     assert assertMsg (secret.rekeyFile != null -> builtins.pathExists secret.rekeyFile) ''
       [1;31mhost ${target}: age.secrets.${secret.id}.rekeyFile ([33m${toString secret.rekeyFile}[m[1;31m) doesn't exist.[0m ${generateHint}

--- a/modules/agenix-rekey.nix
+++ b/modules/agenix-rekey.nix
@@ -85,8 +85,9 @@ let
       # This is important to ensure that the path only changes if there are actual changes to this
       # directory. If we were still using userFlake.outPath + "/secrets/[...]" or something similar,
       # then the path would change on each subsequent build because the flake path changes.
+      rekeyedDir = builtins.path { path = config.age.rekey.localStorageDir; };
       rekeyedPath =
-        builtins.path { path = config.age.rekey.localStorageDir; } + "/${identHash}-${secret.name}.age";
+        builtins.seq (builtins.readDir rekeyedDir) (rekeyedDir + "/${identHash}-${secret.name}.age");
     in
     assert assertMsg (secret.rekeyFile != null -> builtins.pathExists secret.rekeyFile) ''
       [1;31mhost ${target}: age.secrets.${secret.id}.rekeyFile ([33m${toString secret.rekeyFile}[m[1;31m) doesn't exist.[0m ${generateHint}

--- a/modules/agenix-rekey.nix
+++ b/modules/agenix-rekey.nix
@@ -757,6 +757,24 @@ in
           in an effort to not break complex setups (e.g. WSL passthrough).
         '';
       };
+
+      masterIdentitySessionWrapper = mkOption {
+        type = types.nullOr types.package;
+        default = null;
+        description = ''
+          Optional command wrapper used for batch operations that decrypt with
+          master identities. The wrapper is invoked as:
+
+              <wrapper> -- <agenix-command> [args...]
+
+          It can keep plugin state alive for the duration of one command, for
+          example to reuse a hardware-backed identity without exporting it to
+          disk. The wrapper is applied to `agenix rekey` and
+          `agenix update-masterkeys`; ordinary one-file operations are not
+          changed. At most one distinct wrapper may be configured across the
+          nodes passed to `agenix-rekey.configure`.
+        '';
+      };
     };
   };
 

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -27,6 +27,13 @@ let
   mergeArray = f: unique (concatLists (mapAttrsToList (_: f) nodes));
   mergedAgePlugins = mergeArray (x: x.config.age.rekey.agePlugins or [ ]);
   mergedMasterIdentities = mergeArray (x: x.config.age.rekey.masterIdentities or [ ]);
+  mergedMasterIdentitySessionWrappers = mergeArray (
+    x:
+    if x.config.age.rekey.masterIdentitySessionWrapper == null then
+      [ ]
+    else
+      [ x.config.age.rekey.masterIdentitySessionWrapper ]
+  );
   mergedExtraEncryptionPubkeys = mergeArray (x: x.config.age.rekey.extraEncryptionPubkeys or [ ]);
   mergedSecrets = mergeArray (
     x: filter (y: y != null) (mapAttrsToList (_: s: s.rekeyFile) x.config.age.secrets)
@@ -46,6 +53,14 @@ let
   extraEncryptionPubkeyArgs = concatStringsSep " " (map pubkeyOpt extraEncryptionPubkeys);
   # For decryption, we require access to all master identities
   decryptionMasterIdentityArgs = toIdentityArgs mergedMasterIdentities;
+
+  masterIdentitySessionWrapper =
+    if builtins.length mergedMasterIdentitySessionWrappers > 1 then
+      throw "agenix-rekey: multiple masterIdentitySessionWrapper packages were configured; select one wrapper for all nodes"
+    else if mergedMasterIdentitySessionWrappers == [ ] then
+      null
+    else
+      builtins.head mergedMasterIdentitySessionWrappers;
 
   userFlakeDir = toString userFlake.outPath;
   relativeToFlake =
@@ -186,6 +201,7 @@ in
   inherit relativeToFlake;
   inherit validRelativeSecretPaths;
   inherit mergedSecrets;
+  inherit masterIdentitySessionWrapper;
 
   # Premade shell commands to encrypt and decrypt secrets.
   # NOTE: In order to keep compatibility with existing generator setups,

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -44,8 +44,8 @@ let
   toIdentityArgs = identities: concatStringsSep " " (map (x: "-i ${x.identity}") identities);
 
   ageProgram = getExe (agePackage pkgs);
-  # Collect all paths to enabled age plugins
-  envPath = ''PATH="$PATH"${concatMapStrings (x: ":${escapeShellArg x}/bin") mergedAgePlugins}'';
+  # Prefer explicitly configured plugins over ambient versions from the caller's PATH.
+  envPath = ''PATH="${concatMapStrings (x: "${escapeShellArg x}/bin:") mergedAgePlugins}$PATH"'';
   # Explicitly specified recipients, containing both the explicit master pubkeys as well as the extra pubkeys
   extraEncryptionPubkeys =
     filter (x: x != null) (catAttrs "pubkey" mergedMasterIdentities) ++ mergedExtraEncryptionPubkeys;

--- a/tests/cases/simple/flake.nix
+++ b/tests/cases/simple/flake.nix
@@ -60,12 +60,21 @@
 
           # configuration.nix
           (
-            { config, ... }:
+            { config, pkgs, ... }:
             {
               services.openssh.enable = true;
               age.rekey = {
                 hostPubkey = ./host.pub;
                 masterIdentities = [ ./key.txt ];
+                masterIdentitySessionWrapper = pkgs.writeShellApplication {
+                  name = "test-master-identity-session";
+                  text = ''
+                    echo 'Master identity session started.'
+                    [[ "$1" == -- ]]
+                    shift
+                    exec "$@"
+                  '';
+                };
                 storageMode = "local";
                 localStorageDir = ./. + "/secrets/rekeyed/${config.networking.hostName}";
               };

--- a/tests/cases/simple/test.sh
+++ b/tests/cases/simple/test.sh
@@ -1,3 +1,41 @@
+assert_before() {
+  local output=$1
+  local first=$2
+  local second=$3
+  local first_line second_line
+
+  first_line=$(grep -n -m1 -F "$first" <<< "$output" | cut -d: -f1)
+  second_line=$(grep -n -m1 -F "$second" <<< "$output" | cut -d: -f1)
+  if [[ -z "$first_line" || -z "$second_line" || "$first_line" -ge "$second_line" ]]; then
+    echo "Expected '$first' before '$second'"
+    echo "$output"
+    exit 1
+  fi
+}
+
+if ! rekey_output=$(agenix rekey 2>&1); then
+  echo "$rekey_output"
+  exit 1
+fi
+echo "$rekey_output"
+assert_before "$rekey_output" 'Planned operations:' 'Master identity session started.'
+assert_before "$rekey_output" 'Master identity session started.' 'Rekeying'
+
+if ! update_output=$(agenix update-masterkeys 2>&1); then
+  echo "$update_output"
+  exit 1
+fi
+echo "$update_output"
+assert_before "$update_output" 'Planned operations:' 'Master identity session started.'
+assert_before "$update_output" './secret.age' 'Master identity session started.'
+
+help_output=$(agenix update-masterkeys --help 2>&1)
+if grep -Fq 'Master identity session started.' <<< "$help_output"; then
+  echo 'Help unexpectedly started a master identity session.'
+  exit 1
+fi
+
+# Updating the source ciphertext changes local rekey output paths.
 agenix rekey
 
 darwin_secret_file="$(nix eval --raw /tmp/test#darwinConfigurations.host-darwin.config.age.secrets.secret.file)"


### PR DESCRIPTION
This adds an optional `age.rekey.masterIdentitySessionWrapper` for batch operations.

The wrapper is applied to `agenix rekey` and `agenix update-masterkeys`, while ordinary single-file operations remain unchanged. It lets a hardware-backed plugin keep command-scoped state without exporting identities or writing secrets to disk.

Before either batch command enters that session, it now prints the complete operation plan. Rekey shows each host and secret target, current files, orphan removal, Git staging, and store work. Update-masterkeys lists every source file it will process. Help and path-inspection commands stay sessionless.

Configured age plugins now take precedence over ambient versions in the caller PATH. Without that ordering, a dev shell could select an older plugin binary and silently bypass the session broker.

Validation: the main flake check, treefmt, shellcheck, and generated app builds pass. Against canix, a dummy rekey smoke test printed its full 422-line plan before execution; update-masterkeys printed its full 103-line plan before attempting the first file. Atlas and nomad still evaluate to the same session wrapper and their correct host-local primary identities.

The separate VM test flake is currently blocked before command execution by its pre-existing Nixpkgs 25.05 and nix-darwin 25.11 lock mismatch. Supplying a compatible Darwin input gets past that mismatch, but the offline VM then lacks its Darwin bootstrap closure; this PR does not alter that test lock.